### PR TITLE
Dialog changes

### DIFF
--- a/functions/src/strings.js
+++ b/functions/src/strings.js
@@ -448,7 +448,7 @@ module.exports = {
       acknowledges: [
         'Welcome to music at the Internet Archive.'
       ],
-      speech: 'You can listen to 78s or concerts; or ask me for an artist or genre. Which would you like to listen to?',
+      speech: 'You can listen to our collections of 78s or live concerts. Which would you like to listen to?',
       suggestions: ['78s', 'Live Concerts']
     },
 

--- a/functions/tests/actions/welcome.spec.js
+++ b/functions/tests/actions/welcome.spec.js
@@ -22,7 +22,7 @@ describe('actions', () => {
       expect(dialog.ask).have.been.calledOnce;
       expect(dialog.ask.args[0][1]).to.have.property('reprompt');
       expect(dialog.ask.args[0][1]).to.have.property('speech')
-        .to.equal('Welcome to music at the Internet Archive. You can listen to 78s or concerts; or ask me for an artist or genre. Which would you like to listen to?');
+        .to.equal('Welcome to music at the Internet Archive. You can listen to our collections of 78s or live concerts. Which would you like to listen to?');
       expect(dialog.ask.args[0][1]).to.have.property('suggestions')
         .with.members(['78s', 'Live Concerts']);
     });
@@ -31,7 +31,7 @@ describe('actions', () => {
       let app = mockApp();
       welcome.handler(app);
       expect(dialog.ask.args[0][1]).to.have.property('reprompt')
-        .to.include('You can listen to 78s or concerts; or ask me for an artist or genre. Which would you like to listen to?');
+        .to.include('You can listen to our collections of 78s or live concerts. Which would you like to listen to?');
     });
 
     it('should reset query slots', () => {

--- a/functions/tests/integration/alexa/dialog.yaml
+++ b/functions/tests/integration/alexa/dialog.yaml
@@ -1,7 +1,7 @@
 ---
 
 - scenario: 'startup'
-  launch: 'Welcome to music at the Internet Archive. You can listen to 78s or concerts; or ask me for an artist or genre. Which would you like to listen to?'
+  launch: 'Welcome to music at the Internet Archive. You can listen to our collections of 78s or live concerts. Which would you like to listen to?'
 
 - scenario: 'play music by: live > artist > city > year'
   dialog:


### PR DESCRIPTION
Previous changes we made to dialog allowing for an earlier option to choose "genre" or "artist" before picking a collection were breaking the app's architecture. This will revert some of these changes with the hope that added functionality can be focused into the help messages feature. 