### PR TITLE
feature / More expressive dialog

### DIFF
--- a/functions/src/strings.js
+++ b/functions/src/strings.js
@@ -3,7 +3,7 @@ module.exports = {
    * v2
    */
   acknowledger: [
-    'OK, ',
+    'Okay, ',
     'Got it, ',
     'Sure, ',
     'Alright, ',
@@ -189,7 +189,7 @@ module.exports = {
        * to check our undestanding
        */
       acknowledges: [
-        'Ok! Lets go with the artist {{creator}}!',
+        'Okay! Lets go with the artist {{creator}}!',
         `You've selected {{alias.collectionId}}.`,
       ],
 
@@ -271,7 +271,7 @@ module.exports = {
         '{{coverage}} - good place!',
         '{{coverage}} {{year}} - great choice!',
         '{{year}} - it was an excellent year!',
-        'Ok! Lets go with {{creator}}!',
+        'Okay! Lets go with {{creator}}!',
         `You've selected {{alias.collectionId}}.`,
       ],
 
@@ -361,7 +361,7 @@ module.exports = {
         ],
 
         speech: [
-          'Ok, {{creator}} has played in {{coverage}} sometime in {{years-interval.suggestions}}. Do you have a particular year in mind?',
+          'Okay, {{creator}} has played in {{coverage}} sometime in {{years-interval.suggestions}}. Do you have a particular year in mind?',
         ],
 
         /**
@@ -428,7 +428,7 @@ module.exports = {
         speech: `Excellent! I'll be saying the title to each song.`,
       },
       true: {
-        speech: `Ok, muting song titles.`,
+        speech: `Okay, muting song titles.`,
       },
     },
 

--- a/functions/tests/integration/alexa/dialog.yaml
+++ b/functions/tests/integration/alexa/dialog.yaml
@@ -8,9 +8,9 @@
   - user: 'live collection'
     assistant: 'You''ve selected Live Concerts. What artist would you like to listen to? For example, the Grateful Dead, the Phil Lesh and Friends or the Disco Biscuits?'
   - user: 'Grateful Dead'
-    assistant: 'Ok! Lets go with Grateful Dead! Do you have a specific city and year in mind, like Washington, DC 1973, or would you like me to play something randomly?'
+    assistant: 'Okay! Lets go with Grateful Dead! Do you have a specific city and year in mind, like Washington, DC 1973, or would you like me to play something randomly?'
   - user: 'Washington'
-    assistant: 'Washington - good place! Ok, Grateful Dead has played in Washington sometime in between 1970 and 1995. Do you have a particular year in mind?'
+    assistant: 'Washington - good place! Okay, Grateful Dead has played in Washington sometime in between 1970 and 1995. Do you have a particular year in mind?'
   - user: '1970 year'
     assistant:
       directive: 'AudioPlayer.Play'
@@ -20,7 +20,7 @@
   - user: 'live collection'
     assistant: 'You''ve selected Live Concerts. What artist would you like to listen to? For example, the Grateful Dead, the Phil Lesh and Friends or the Disco Biscuits?'
   - user: 'Grateful Dead'
-    assistant: 'Ok! Lets go with Grateful Dead! Do you have a specific city and year in mind, like Washington, DC 1973, or would you like me to play something randomly?'
+    assistant: 'Okay! Lets go with Grateful Dead! Do you have a specific city and year in mind, like Washington, DC 1973, or would you like me to play something randomly?'
   - user: 'city Washington year 1970'
     assistant:
       directive: 'AudioPlayer.Play'


### PR DESCRIPTION
In response to issue #300 
We've had reviews from users complaining that the `OK` dialog we used in many dialog acknowledgments sounded flat and robotic. After experimenting with the SSML audio tester, I found that speech element tends to pronounce each letter in `OK` singularly which is not reminiscent of human speech. To fix this (an easy fix without adding lots of SSML formatting), I've simply changed `OK` to `Okay` which the speech element pronounces much more naturally. To reflect this change, I've updated dialog tests as well.