### PR TITLE
bugfix / Conv-user-id

### DIFF
--- a/functions/src/platform/assistant/middlewares/log-request.js
+++ b/functions/src/platform/assistant/middlewares/log-request.js
@@ -14,7 +14,7 @@ module.exports = (conv) => {
   debug('\n\n');
   info(`start handling action: ${conv.action}, intent: ${conv.intent}`);
   if (conv.user) {
-    info(`user.id:`, conv.user.id);
+    info(`user.id:`, conv.user.storage);
     info(`user.last:`, conv.user.last);
     info(`user.name:`, util.inspect(conv.user.name));
   } else {


### PR DESCRIPTION
In response to issue #290 
We were getting flags in the debug console about conv.user.id being a depreciated module. To remedy this I modified log-request to use conv.user.storage instead of conv.user.id. Tested on both Alexa and Assistant and no problems.