### PR TITLE
Added Dashbot functionality back into handler.js

### DIFF
--- a/functions/src/platform/assistant/handler.js
+++ b/functions/src/platform/assistant/handler.js
@@ -170,5 +170,9 @@ module.exports = (actionsMap) => {
     pipeline.stage(pipeline.IDLE);
   });
 
-  return functions.https.onRequest(bst.Logless.capture(functions.config().bespoken.key, app), dashbot.configHandler(app));
+  // dashbot.configHandler(app);
+  // return functions.https.onRequest(bst.Logless.capture(functions.config().bespoken.key, app));
+  return functions.https.onRequest(bst.Logless.capture(functions.config().bespoken.key, app, function (req, res) {
+    dashbot.configHandler(app);
+  }));
 };

--- a/functions/src/platform/assistant/handler.js
+++ b/functions/src/platform/assistant/handler.js
@@ -2,7 +2,7 @@ const {dialogflow} = require('actions-on-google');
 const bst = require('bespoken-tools');
 const functions = require('firebase-functions');
 const _ = require('lodash');
-// const dashbotBuilder = require('dashbot');
+const dashbotBuilder = require('dashbot');
 // FIXME: temporal solution details below
 // const domain = require('domain'); // eslint-disable-line
 const Raven = require('raven');
@@ -21,13 +21,10 @@ module.exports = (actionsMap) => {
   const app = dialogflow();
   let handlers = [];
 
-  // dashbot doesn't support official v2 yet
-  // (https://github.com/actionably/dashbot/issues/23)
-  //
-  // const dashbot = dashbotBuilder(
-  //   functions.config().dashbot.key, {
-  //     printErrors: false,
-  //   }).google;
+  const dashbot = dashbotBuilder(
+    functions.config().dashbot.key, {
+      printErrors: false,
+    }).google;
 
   if (actionsMap) {
     handlers = buildHandlers({actionsMap});
@@ -173,5 +170,5 @@ module.exports = (actionsMap) => {
     pipeline.stage(pipeline.IDLE);
   });
 
-  return functions.https.onRequest(bst.Logless.capture(functions.config().bespoken.key, app));
+  return functions.https.onRequest(bst.Logless.capture(functions.config().bespoken.key, app), dashbot.configHandler(app));
 };

--- a/functions/src/platform/assistant/handler.js
+++ b/functions/src/platform/assistant/handler.js
@@ -3,8 +3,8 @@ const {dialogflow} = require('actions-on-google');
 const bst = require('bespoken-tools');
 const functions = require('firebase-functions');
 const _ = require('lodash');
-// const dashbotBuilder = require('dashbot');
-const dashbot = require('dashbot')(functions.config().dashbot.key).google;
+const dashbotBuilder = require('dashbot');
+
 // FIXME: temporal solution details below
 // const domain = require('domain'); // eslint-disable-line
 const Raven = require('raven');
@@ -21,15 +21,12 @@ const logRequest = require('./middlewares/log-request');
 
 module.exports = (actionsMap) => {
   const app = dialogflow();
-  dashbot.configHandler(app);
   let handlers = [];
 
-  /*
   const dashbot = dashbotBuilder(
     functions.config().dashbot.key, {
       printErrors: false,
     }).google;
-    */
 
   if (actionsMap) {
     handlers = buildHandlers({actionsMap});
@@ -178,26 +175,6 @@ module.exports = (actionsMap) => {
   // dashbot.configHandler(app);
 
   return functions.https.onRequest(bst.Logless.capture(functions.config().bespoken.key, app), (req, res) => {
-    // dashbot.configHandler(req, res);
     dashbot.configHandler(app);
   });
-
-  // return functions.https.onRequest(bst.Logless.capture(functions.config().bespoken.key, app));
-
-  /*
-  return functions.https.onRequest(bst.Logless.capture(functions.config().bespoken.key, (req, res) => {
-    const app = new Dialogflow({request: req, response: res});
-    dashbot.configHandler(app);
-  }));
-  */
-  /*
-  return functions.https.onRequest((request, response) => {
-    dashbot.configHandler(app);
-    // return bst.Logless.capture(functions.config().bespoken.key, app);
-    return bst.Logless.capture(functions.config().bespoken.key, (request, response) => {
-      const app = new DialogflowApp({request: request, response: response});
-      dashbot.configHandler(app);
-    });
-  });
-  */
 };


### PR DESCRIPTION
In response to issue #315 
Now that Dashbot has upgraded their services to work with Dialogflow V2, we can turn back on their logging. I have attempted to do this and was able to get it working locally when I tested it. I followed Dashbot documentation and also looked at what Eugene did previously before the service was shut off.