### PR TITLE
fixes #389 and changed .gitignore file for developer workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ functions/firebase-debug.log
 npm-debug.log
 .DS_Store
 
+.env
+functions/.runtimeconfig.json

--- a/functions/src/strings.js
+++ b/functions/src/strings.js
@@ -96,7 +96,7 @@ module.exports = {
     }],
 
     fallback: {
-      // TODO: fix actually we shoudl substitute app name here
+      // TODO: fix actually we should substitute app name here
       // because in alexa it is The Internet Archive Skill
       // but on Google Assistant it would be The Internet Archive Action
       speech:
@@ -120,7 +120,7 @@ module.exports = {
           '<s>You are using Internet Archive service. </s>' +
           '<s>Here we have collections of Live Concerts and 78 <say-as interpret-as="characters">rpm</say-as> records. </s>' +
           '<s>You can ask to playback music of specific genre by asking: </s>' +
-          '<s>play jazz music <break strength="weak"/> or play classic music. </s>' +
+          '<s>Jam to some Jazz <break strength="weak"/> or play classic music. </s>' +
           '<s>As well you can ask me to play specific artist. </s>' +
           '<s>For example by saying: </s>' +
           '<s>play Grateful Dead <break strength="weak"/> or play the Cowboy Junkies. </s>' +
@@ -135,7 +135,7 @@ module.exports = {
             '<s>You are listening <break strength="weak"/> {{playback.title}} <break strength="weak"/> of {{playback.creator}}{{#playback.year}} <break strength="weak"/> {{playback.year}}{{/playback.year}}.</s> ' +
             '<s>But you can select any music which I have in my Internet Archive collection, </s>' +
             '<s>by asking ' +
-            '<break strength="weak"/> play jazz music ' +
+            '<break strength="weak"/> Jam to some Jazz ' +
             '<break strength="weak"/> or <break strength="weak"/> randomly play grateful dead' +
             '<break strength="weak"/> or play any other genre or artist. </s> ' +
             '<s>And finally you can just answer my questions so I would help you to find right records. </s>' +


### PR DESCRIPTION
Partially Fixed #389 and changed .gitignore file for developer workflow. `.env` and `functions/.runtimeconfig.json` was not to be committed so added them to `.gitignore` file. @hyzhak would you please review and help. 

I wanted to ask 2 things. 
For 
- [ ] fallback handler drop "but I can help you to find music records and play it."
I was deleting [line 104](https://github.com/internetarchive/internet-archive-google-action/blob/master/functions/src/strings.js#L104) but was getting error in tests. Tests were failing because of [this line](https://github.com/internetarchive/internet-archive-google-action/blob/master/functions/tests/integration/alexa/dialog.yaml#L298). Would you please tell how to update that string for tests in `.yml file`.

- [ ] for Live Concerts don't say "Albums". Say "Concerts"

I couldn't understand this part. Would you please explain. 